### PR TITLE
Restrict Jest to a single thread

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,4 +16,4 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: $(yarn global bin)/lerna run build
-      - run: yarn test
+      - run: yarn test -w 1


### PR DESCRIPTION
## What's changing

Jest now runs with 1 thread in CI builds.

## What else might be impacted? 

Nothing

## Checklist

[ ] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.)
