### PR TITLE
test(EnvironmentField): Added tests for EnvironmentField component

### DIFF
--- a/packages/extension/src/components/dashboard/fields/EnvironmentField.jsx
+++ b/packages/extension/src/components/dashboard/fields/EnvironmentField.jsx
@@ -6,7 +6,7 @@ class EnvironmentField extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      rawValue: ''
+      rawValue: this.getValue(this.props.selectedCmd.parameters)
     }
   }
 
@@ -16,7 +16,7 @@ class EnvironmentField extends React.Component {
       .join(',')
   }
 
-  updateParameters(e) {
+  updateParameters = (e) => {
     this.setState({ rawValue: e.target.value }, () => {
       if (this.state.rawValue.includes('=')) {
         const pairs = this.state.rawValue.split(',').map(split => {
@@ -36,12 +36,6 @@ class EnvironmentField extends React.Component {
       } else if (this.state.rawValue === '') {
         this.props.updateSelectedCommand({ parameters: {} }, true)
       }
-    })
-  }
-
-  componentWillMount() {
-    this.setState({
-      rawValue: this.getValue(this.props.selectedCmd.parameters)
     })
   }
 

--- a/packages/extension/test/components/dashboard/fields/EnvironmentField.test.js
+++ b/packages/extension/test/components/dashboard/fields/EnvironmentField.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import EnvironmentField from '../../../../src/components/dashboard/fields/EnvironmentField.jsx'
 
 afterEach(() => {
@@ -7,13 +7,54 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
+const getComponent = (props = {}) => (
+  <EnvironmentField 
+    updateSelectedCommand={props.updateSelectedCommand || jest.fn()}
+    selectedCmd={props.selectedCmd || { parameters: {}}}
+    isCmdEditable={props.isCmdEditable || false}
+  />
+)
+
 describe('EnvironmentField', () => {
   it('renders', () => {
-    const { container, getByText } = render(
-      <EnvironmentField selectedCmd={{ parameters: {} }} />
-    )
-    getByText('Environment')
+    const { container, getByText } = render(getComponent())
+    expect(getByText('Environment')).not.toBeNull()
     expect(container.querySelector('input')).not.toBeNull()
+  })
+
+  it('sets input value', () => {
+    const selectedCmd = {
+      parameters: {
+        key1: 'param1'
+      }
+    }
+    const { container } = render(getComponent({selectedCmd}))
+    expect(container.querySelector('input').value).toEqual('key1=param1')
+  })
+
+  it('sets multiple input values', () => {
+    const selectedCmd = {
+      parameters: {
+        key1: 'param1',
+        key2: 'param2',
+        key3: 'param3'
+      }
+    }
+    const { container } = render(getComponent({selectedCmd}))
+    const expectedOutput = 'key1=param1,key2=param2,key3=param3'
+    expect(container.querySelector('input').value).toEqual(expectedOutput)
+  })
+
+  it('is editable', () => {
+    const { container } = render(getComponent({ isCmdEditable: true }))
+    expect(container.querySelector('input').disabled).toEqual(false)
+  })
+
+  it('handle input change', () => {
+    const { getByPlaceholderText } = render(getComponent({ isCmdEditable: true }))
+    const input = getByPlaceholderText('KEY1=VALUE,KEY2=VALUE...')
+    fireEvent.change(input, { target: { value: 'key1=param1' } })
+    expect(input.value).toEqual('key1=param1')
   })
 
   // TODO more tests ...

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -54,11 +54,11 @@ async function resolveMatches(string, defaults, context) {
         .reduce((acc, cv) => acc[cv], context)
       if (process && process.env && process.env[match[1]]) {
         return { old: match[0], new: process.env[match[1]] }
+      } else if (currentContext[parts[parts.length - 1]]) {
+        return { old: match[0], new: currentContext[parts[parts.length - 1]] }
       } else if (defaults[match[1]]) {
         const result = await defaults[match[1]].action()
         return { old: match[0], new: result }
-      } else if (currentContext[parts[parts.length - 1]]) {
-        return { old: match[0], new: currentContext[parts[parts.length - 1]] }
       }
     })
   )

--- a/packages/utils/test/index.test.js
+++ b/packages/utils/test/index.test.js
@@ -23,6 +23,11 @@ describe('String replacements', () => {
       expect(result).toEqual(todaysDate)
     )
   })
+  it('should replace todaysDate from context instead of defaults', () => {
+    return doReplace('{todaysDate}', { todaysDate: '01/01/2019' }).then(result =>
+      expect(result).toEqual('01/01/2019')
+    )
+  })
   it('should not replace {potato}', () => {
     return doReplace('{potato}').then(result =>
       expect(result).toEqual('{potato}')
@@ -35,7 +40,7 @@ describe('String replacements', () => {
   })
   it('should replace {millis}', () => {
     return doReplace('{millis}').then(result =>
-      expect(result).not.toEqual('{random}')
+      expect(result).not.toEqual('{millis}')
     )
   })
   it('should return a string with no braces', () => {
@@ -62,11 +67,6 @@ describe('String replacements', () => {
     return doReplace('{potato.type.0}', {
       potato: { type: ['pancakes'] }
     }).then(result => expect(result).toEqual('pancakes'))
-  })
-  it('should not replace a static string if no context', () => {
-    return doReplace('{potato}').then(result =>
-      expect(result).toEqual('{potato}')
-    )
   })
   it('should replace a string nested in a JSON string', () => {
     const todaysDate = moment().format('MM/D/YYYY')


### PR DESCRIPTION
## What's changing
- Added tests for EnvironmentField component (related to issue https://github.com/intuit/ReplayWeb/issues/5).
- Fixed a Utils test and removed a duplicated Utils test.
- Changed `updateParameters` function to be an arrow function to bind `this` for input change
- Removed `componentWillMount` usage from EnvironmentField component to suppress React warning

## What else might be impacted? 
Utils doReplace will use context before using default values for `todaysDate`

## Checklist

[x] Unit tests (updated and/or added)
[x] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.14.118.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
