### PR TITLE
test(utils/xpath): Additional unit test for xpath utils - ignore pattern params

### DIFF
--- a/packages/utils/test/index.test.js
+++ b/packages/utils/test/index.test.js
@@ -349,6 +349,38 @@ describe('xpath', () => {
     })
     expect(xpath(el)).toEqual('//*[@data-automation-id="parent"]/div')
   })
+  it('should process ignore pattern', () => {
+    let el = divBuilder({
+      parentNode: divBuilder({
+        'data-automation-id': 'ignoreThis'
+      })
+    })
+    expect(xpath(el, null, null, [/IGNORETHIS/i])).toEqual('/html/div/div')
+
+    el = divBuilder({
+      automationid: 'testAutomationId',
+    })
+    expect(xpath(el, null, null, [/automation/i])).toEqual('/html/div')
+
+    el = divBuilder({
+      id: 'id',
+    })
+    expect(xpath(el, null, null, [/id/i])).toEqual('/html/div')
+
+    el = divBuilder({
+      "data-auto-sel": 'auto sel',
+    })
+    expect(xpath(el, null, null, [/auto-sel/i])).toEqual('/html/div')
+  })
+  it('should handle given cur node', () => {
+    const parent = divBuilder({
+      name: 'parent'
+    })
+    const el = divBuilder({
+      parentNode: parent
+    })
+    expect(xpath(el, parent, null)).toEqual('//*[@name="parent"]/')
+  })
 })
 
 describe('getLocator', () => {


### PR DESCRIPTION
## What's changing

Additional unit test for utils/xpath ignore pattern params (contribute to #5 ).

## What else might be impacted? 

N/A

## Checklist

[X] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.15.242.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
