### PR TITLE
adding additional unit tests to duplicate modal and fixing context bi…

### DIFF
--- a/packages/extension/src/components/Modals/DuplicateModal.jsx
+++ b/packages/extension/src/components/Modals/DuplicateModal.jsx
@@ -9,6 +9,8 @@ class DuplicateModal extends React.Component {
       duplicateName: this.props.src ? `${this.props.src.name}_new` : ''
     }
     this.onChange = this.onChange.bind(this)
+    this.onDuplicate = this.onDuplicate.bind(this)
+    this.onCancel = this.onCancel.bind(this)
   }
 
   componentWillReceiveProps(nextProps) {

--- a/packages/extension/test/components/Modals/DuplicateModal.test.js
+++ b/packages/extension/test/components/Modals/DuplicateModal.test.js
@@ -1,6 +1,17 @@
 import React from 'react'
-import { cleanup, render, fireEvent } from '@testing-library/react'
+import { cleanup, render, fireEvent, act } from '@testing-library/react'
 import DuplicateModal from '../../../src/components/Modals/DuplicateModal.jsx'
+import { message } from 'antd'
+
+jest.mock('antd', () => {
+  return {
+    ...(jest.requireActual('antd')),
+    message: {
+      success: jest.fn(),
+      error: jest.fn()
+    }
+  }
+})
 
 afterEach(() => {
   cleanup()
@@ -36,5 +47,46 @@ describe('DuplicateModal', () => {
 
     expect(input.value).toEqual('duplicate me')
   })
+
+  describe('onDuplicate', () => {
+    let mockProps
+
+    beforeEach(() => {
+      mockProps = {
+        src: 'test',
+        visible: true,
+        duplicate: jest.fn().mockResolvedValue({}),
+        closeModal: jest.fn()
+      }
+    })
+
+    const renderModalAndClose = (props) => {
+      const {getByText} = render(getComponent(props))
+      const modalOk = getByText("Save")
+
+      return act(async () => {
+        fireEvent.click(modalOk)
+      })
+    }
+
+    it('should close the modal on success', async () => {
+      await renderModalAndClose(mockProps)
+
+      expect(mockProps.duplicate).toHaveBeenCalled()
+      expect(message.success).toHaveBeenCalledWith('successfully duplicated!', 1.5)
+      expect(mockProps.closeModal).toHaveBeenCalled()
+    })
+
+    it('should log error message on failure', async () => {
+      const errorMessage = 'error error'
+      mockProps.duplicate = jest.fn().mockRejectedValue({message: errorMessage})
+
+      await renderModalAndClose(mockProps)
+
+      expect(mockProps.duplicate).toHaveBeenCalled()
+      expect(message.error).toHaveBeenCalledWith(errorMessage, 1.5)
+    })
+  })
+
   // TODO more tests ...
 })


### PR DESCRIPTION
…nding

Thank you for contributing this pull request!

Please make the PR against the `master` branch, add a description of what's changing, and link any relevant issues or PRs.

adding ontop of issue #5

## What's changing

additional unit tests to test the duplicate modal close functionality

## What else might be impacted? 

...

## Checklist

[ ] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.)

@Celeo there seems to be a context issue in duplicatemodal on save and cancel during testing which this PR should have addressed as well.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.24.317.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
