### PR TITLE
Adding unit test cases to increase code coverage

### DIFF
--- a/packages/extension/test/components/Project/FolderBrowser.test.js
+++ b/packages/extension/test/components/Project/FolderBrowser.test.js
@@ -1,6 +1,11 @@
 import React from 'react'
-import { cleanup, render } from '@testing-library/react'
+import { shallow } from 'enzyme'
+import { cleanup} from '@testing-library/react'
 import FolderBrowser from '../../../src/components/Project/FolderBrowser.jsx'
+
+beforeEach(() => {
+  global.browser = {}
+})
 
 afterEach(() => {
   cleanup()
@@ -25,13 +30,27 @@ const getComponent = (props = {}) => {
 
 describe('FolderBrowser', () => {
   it('renders', () => {
-    const { getByText } = render(getComponent())
-    getByText('Choose Folder')
-    getByText('Jump To')
-    getByText('No data')
-    getByText('Cancel')
-    getByText('Select')
+    const wrapper = shallow(getComponent())
+    expect(wrapper.find('Choose Folder')).not.toBeNull()
+    expect(wrapper.find('Jump To')).not.toBeNull()
+    expect(wrapper.find('No data')).not.toBeNull()
+    expect(wrapper.find('Cancel')).not.toBeNull()
+    expect(wrapper.find('Select')).not.toBeNull()
+    expect(wrapper.find('Modal')).not.toBeNull()
+    expect(wrapper.find('Button')).not.toBeNull()
+    expect(wrapper.find('Icon')).not.toBeNull()
+    expect(wrapper.find('Input')).not.toBeNull()
+    expect(wrapper.find('Table')).not.toBeNull()
   })
 
   // TODO more tests ...
+  it('changeFolder', () => {
+    const listDirectory = jest.fn()
+    const folder = {}
+    const wrapper = shallow(getComponent({folder, listDirectory}))
+    const instance = wrapper.instance()
+    instance.changeFolder(folder)
+    expect(listDirectory).toHaveBeenCalledWith(folder)
+    expect(wrapper.state('loading')).toEqual(true)
+  })
 })

--- a/packages/extension/test/components/Project/ProjectModal.test.js
+++ b/packages/extension/test/components/Project/ProjectModal.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import { shallow } from 'enzyme'
 import { cleanup, render } from '@testing-library/react'
 import ProjectModal from '../../../src/components/Project/ProjectModal.jsx'
-
+import { Input, Modal, Button} from 'antd'
 afterEach(() => {
   cleanup()
   jest.clearAllMocks()
@@ -38,6 +39,89 @@ describe('ProjectModal', () => {
     getByText('Path')
     getByText('Choose Test and Block folders')
     getByText('These paths are relative to your project path:')
+  })
+
+  it('onClick of "Button", id passed from props does not exists', () => {
+    const browseProject = jest.fn()
+    const wrapper = shallow(getComponent({browseProject}))
+    wrapper.find(Button).simulate('click')
+    expect(browseProject).toHaveBeenCalled()
+  })
+
+  it('onClick of "Button", id passed from props exists', () => {
+    const id = {}
+    const browseProject = jest.fn()
+    const browseBlock = jest.fn()
+    const browseTest = jest.fn()
+    const wrapper = shallow(getComponent({browseProject, browseBlock, browseTest, id}))
+    wrapper.find(Button).at(0).simulate('click')
+    expect(browseProject).toHaveBeenCalled()
+    wrapper.find(Button).at(1).simulate('click')
+    expect(browseTest).toHaveBeenCalled()
+    wrapper.find(Button).at(2).simulate('click')
+    expect(browseBlock).toHaveBeenCalled()
+  })
+
+  it('onClick of "Button", id is null while projectPath exist and existingConfig is not null', () => {
+    const id = null
+    const projectPath = {}
+    const existingConfig = {}
+    const browseProject = jest.fn()
+    const browseBlock = jest.fn()
+    const browseTest = jest.fn()
+    const wrapper = shallow(getComponent({browseProject, browseBlock, browseTest, id, projectPath, existingConfig}))
+    wrapper.find(Button).at(0).simulate('click')
+    expect(browseProject).toHaveBeenCalled()
+    wrapper.find(Button).at(1).simulate('click')
+    expect(browseTest).toHaveBeenCalled()
+    wrapper.find(Button).at(2).simulate('click')
+    expect(browseBlock).toHaveBeenCalled()
+  })
+
+  it('onChange of "Menu" is triggered', () => {
+    const clearProjectSetup = jest.fn()
+    const closeModal = jest.fn()
+    const firstTime = false
+    const wrapper = shallow(getComponent({clearProjectSetup, closeModal, firstTime}))
+    wrapper.find(Modal).simulate('cancel')
+    expect(clearProjectSetup).toHaveBeenCalled()
+    expect(closeModal).toHaveBeenCalled()
+    expect(wrapper.state('name')).toEqual('')
+  })
+
+  it('onBlur of "Input" is triggered', () => {
+    const checkForExistingConfig = jest.fn()
+    const wrapper = shallow(getComponent({checkForExistingConfig}))
+    wrapper.find(Input).at(1).simulate('blur')
+    expect(checkForExistingConfig).toHaveBeenCalled()
+  })
+
+  it('onOk of "Menu" is triggered and id passed from props does not exists', () => {
+    const id = null
+    const updateProject = jest.fn()
+    const createProject = jest.fn()
+    const closeModal = jest.fn()
+    const clearProjectSetup = jest.fn()
+    const wrapper = shallow(getComponent({id, updateProject, createProject, closeModal, clearProjectSetup}))
+    wrapper.find(Modal).simulate('ok')
+    expect(createProject).toHaveBeenCalled()
+    expect(closeModal).toHaveBeenCalled()
+    expect(clearProjectSetup).toHaveBeenCalled()
+    expect(wrapper.state('name')).toEqual('')
+  })
+
+  it('onOk of "Menu" is triggered and id passed from props exists', () => {
+    const id = {}
+    const updateProject = jest.fn()
+    const createProject = jest.fn()
+    const closeModal = jest.fn()
+    const clearProjectSetup = jest.fn()
+    const wrapper = shallow(getComponent({id, updateProject, createProject, closeModal, clearProjectSetup}))
+    wrapper.find(Modal).simulate('ok')
+    expect(updateProject).toHaveBeenCalled()
+    expect(closeModal).toHaveBeenCalled()
+    expect(clearProjectSetup).toHaveBeenCalled()
+    expect(wrapper.state('name')).toEqual('')
   })
 
   // TODO more tests ...


### PR DESCRIPTION
## What's changing

For Issue #5, Added unit test cases to increase code coverage of following files : packages/extension/src/components/Project/ProjectModal.jsx
packages/extension/src/components/Project/FolderBrowser.jsx

## What else might be impacted? 

Nothing

## Checklist

[x] Unit tests (updated and/or added)
[x] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.25.298.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
