### PR TITLE
Update installation documentation for testrunner package

### DIFF
--- a/packages/testrunner/README.md
+++ b/packages/testrunner/README.md
@@ -41,7 +41,7 @@ yarn add -D @wdio/cli @wdio/local-runner @wdio/junit-reporter @wdio/mocha-framew
 or
 
 ```sh
-yarn add -D @wdio/cli @wdio/local-runner @wdio/junit-reporter @wdio/mocha-framework @wdio/selenium-standalone-service @wdio/spec-reporter webdriverio chai
+npm install -D @wdio/cli @wdio/local-runner @wdio/junit-reporter @wdio/mocha-framework @wdio/selenium-standalone-service @wdio/spec-reporter webdriverio chai
 ```
 
 #### Optional Peer Dependencies


### PR DESCRIPTION
## What's changing
- Updated documentation for installing `@wdio` scope packages using `npm`
  - The `yarn` command was duplicated in both places so added the `npm` one

## What else might be impacted? 

...

## Checklist

[ ] Unit tests (updated and/or added)
[x] Documentation (function/class docs, comments, etc.)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.26.365.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
