### PR TITLE
Add unit tests for RenameModal

### DIFF
--- a/packages/extension/src/components/Modals/RenameModal.jsx
+++ b/packages/extension/src/components/Modals/RenameModal.jsx
@@ -9,6 +9,9 @@ class RenameModal extends React.Component {
     this.state = {
       rename: ''
     }
+    this.onChange = this.onChange.bind(this)
+    this.onRename = this.onRename.bind(this)
+    this.onCancel = this.onCancel.bind(this)
   }
 
   componentWillReceiveProps(nextProps) {

--- a/packages/extension/test/components/Modals/RenameModal.test.js
+++ b/packages/extension/test/components/Modals/RenameModal.test.js
@@ -42,10 +42,12 @@ describe('RenameModal', () => {
     getByText('Save')
   })
 
-  it('should change rename on input change', () => {
+  it('should change rename on input change', async () => {
     const { getByPlaceholderText } = render(getComponent())
     const input = getByPlaceholderText('test case name')
-    fireEvent.change(input, { target: { value: 'new name' }})
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'new name' }})
+    })
     expect(input.value).toEqual('new name')
   })
 

--- a/packages/extension/test/components/Modals/RenameModal.test.js
+++ b/packages/extension/test/components/Modals/RenameModal.test.js
@@ -1,6 +1,18 @@
 import React from 'react'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, fireEvent, act } from '@testing-library/react'
 import RenameModal from '../../../src/components/Modals/RenameModal.jsx'
+import * as C from '../../../src/common/constant'
+import { message } from 'antd'
+
+jest.mock('antd', () => {
+  return {
+    ...(jest.requireActual('antd')),
+    message: {
+      success: jest.fn(),
+      error: jest.fn()
+    }
+  }
+})
 
 afterEach(() => {
   cleanup()
@@ -30,5 +42,84 @@ describe('RenameModal', () => {
     getByText('Save')
   })
 
-  // TODO more tests ...
+  it('should change rename on input change', () => {
+    const { getByPlaceholderText } = render(getComponent())
+    const input = getByPlaceholderText('test case name')
+    fireEvent.change(input, { target: { value: 'new name' }})
+    expect(input.value).toEqual('new name')
+  })
+
+  it('should rename test case on modal OK', async () => {
+    const mockProps = {
+      editorStatus: C.EDITOR_STATUS.TESTS,
+      renameTestCase: jest.fn().mockResolvedValue(),
+      closeModal: jest.fn()
+    }
+    const { getByText } = render(getComponent(mockProps))
+    const modalOk = getByText('Save')
+    await act(async () => {
+      fireEvent.click(modalOk)
+    })
+    expect(mockProps.renameTestCase).toHaveBeenCalled()
+    expect(mockProps.closeModal).toHaveBeenCalled()
+  })
+
+  it('should rename block on modal OK', async () => {
+    const mockProps = {
+      editorStatus: C.EDITOR_STATUS.BLOCKS,
+      renameBlock: jest.fn().mockResolvedValue(),
+      closeModal: jest.fn()
+    }
+    const { getByText } = render(getComponent(mockProps))
+    const modalOk = getByText('Save')
+    await act(async () => {
+      fireEvent.click(modalOk)
+    })
+    expect(mockProps.renameBlock).toHaveBeenCalled()
+    expect(mockProps.closeModal).toHaveBeenCalled()
+  })
+
+  it('should rename suites on modal OK', async () => {
+    const mockProps = {
+      editorStatus: C.EDITOR_STATUS.SUITES,
+      renameSuite: jest.fn().mockResolvedValue(),
+      closeModal: jest.fn()
+    }
+    const { getByText } = render(getComponent(mockProps))
+    const modalOk = getByText('Save')
+    await act(async () => {
+      fireEvent.click(modalOk)
+    })
+    expect(mockProps.renameSuite).toHaveBeenCalled()
+    expect(mockProps.closeModal).toHaveBeenCalled()
+  })
+
+  it('should catch error on modal OK', async () => {
+    const errorMessage = 'error msg'
+    const mockProps = {
+      editorStatus: C.EDITOR_STATUS.SUITES,
+      renameSuite: jest.fn().mockRejectedValue({message: errorMessage}),
+      closeModal: jest.fn()
+    }
+    const { getByText } = render(getComponent(mockProps))
+    const modalOk = getByText('Save')
+    await act(async () => {
+      fireEvent.click(modalOk)
+    })
+    expect(message.error).toHaveBeenCalledWith(errorMessage, 1.5)
+  })
+  
+  it('should call onCancel on modal cancel', async () => {
+    const mockProps = {
+      closeModal: jest.fn()
+    }
+    const { getByPlaceholderText, getByText } = render(getComponent(mockProps))
+    const input = getByPlaceholderText('test case name')
+    const modalCancel = getByText('Cancel')
+    await act(async () => {
+      fireEvent.click(modalCancel)
+    })
+    expect(mockProps.closeModal).toHaveBeenCalled()
+    expect(input.value).toEqual('')
+  })
 })


### PR DESCRIPTION
Thank you for contributing this pull request!

Please make the PR against the `master` branch, add a description of what's changing, and link any relevant issues or PRs.

Add unit tests for issue #5 

## What's changing

Adding unit tests for RenameModal

## What else might be impacted? 

RenameModal didn't have the correct bindings so using 'this' context from the unit tests didn't work so I added the bindings.

## Checklist

[x] Unit tests (updated and/or added)
[x] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.27.352.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
