### PR TITLE
Adding tests for dashboard/fields/OneField in extension.

### DIFF
--- a/packages/extension/test/components/dashboard/fields/OneField.test.js
+++ b/packages/extension/test/components/dashboard/fields/OneField.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { cleanup, render } from '@testing-library/react'
+import { mount } from 'enzyme'
 import OneField from '../../../../src/components/dashboard/fields/OneField.jsx'
 
 jest.mock('../../../../src/components/dashboard/fields/CommandButtons', () => {
@@ -19,6 +20,7 @@ const getComponent = (props = {}) => (
     updateSelectedCommand={props.updateSelectedCommand || jest.fn()}
     isCmdEditable={props.isCmdEditable || false}
     selectedCmd={props.selectedCmd || { parameters: {}}}
+    blocks={props.blocks || null}
   />
 )
 
@@ -53,6 +55,22 @@ describe('OneField', () => {
     expect(container.querySelector('input').disabled).toEqual(false)
   })
 
+  it('text input onChange', () => {
+    const mockUpdateSelectedCommand = jest.fn()
+    const props = {
+      isCmdEditable: true,
+      updateSelectedCommand: mockUpdateSelectedCommand,
+      selectedCmd: {
+        command: 'assertJsonInContext'
+      }
+    }
+    const wrapper = mount(getComponent(props))
+    const input = wrapper.find('input')
+    input.simulate('change', {target: {value: "test"}})
+    expect(mockUpdateSelectedCommand.mock.calls.length).toBe(1)
+  })
+  
+
   it('checkbox renders', () => {
     const { container } = render(
         getComponent({isCmdEditable: true,
@@ -72,9 +90,36 @@ describe('OneField', () => {
     expect(checkbox.value).toEqual('')
   })
 
+  it('checkbox onChange', () => {
+    const mockUpdateSelectedCommand = jest.fn()
+    const props = {
+      isCmdEditable: true,
+      updateSelectedCommand: mockUpdateSelectedCommand,
+      selectedCmd: {
+        command: 'assertCheckboxState'
+      }
+    }
+    const wrapper = mount(getComponent(props))
+    const checkbox = wrapper.find('.ant-checkbox-input')
+    checkbox.simulate('change', {target: {checked: false}})
+    expect(mockUpdateSelectedCommand.mock.calls.length).toBe(1)
+  })
+
+  it('checkbox disabled', () => {
+    const props = {
+      isCmdEditable: false,
+      selectedCmd: {
+        command: 'assertCheckboxState'
+      }
+    }
+    const wrapper = mount(getComponent(props))
+    expect(wrapper.find('input').at(1).props().disabled).toBe(true)
+  })
+
   it('select renders', () => {
     const { container } = render(
         getComponent({isCmdEditable: true,
+          blocks: [{name: "Block1"}, {name: "Block2"}, {name: "Block3"}],
           selectedCmd: {
             command: 'runBlock',
             parameters: {
@@ -83,6 +128,31 @@ describe('OneField', () => {
     expect(checkbox.disabled).toEqual(false)
     expect(checkbox.className).toEqual('ant-select-search__field')
     expect(checkbox.value).toEqual('')
+  })
+
+  it('select disabled', () => {
+    const props = {
+      isCmdEditable: false,
+      selectedCmd: {
+        command: 'http'
+      }
+    }
+    const wrapper = mount(getComponent(props))
+    expect(wrapper.find('Select').at(0).props().disabled).toBe(true)
+  })
+
+  it('select onChange', () => {
+    const mockUpdateSelectedCommand = jest.fn()
+    const props = {
+      isCmdEditable: true,
+      selectedCmd: {
+        command: 'http'
+      },
+      updateSelectedCommand: mockUpdateSelectedCommand
+    }
+    const wrapper = mount(getComponent(props))
+    wrapper.find('Select').at(0).prop('onChange')('PUT')
+    expect(mockUpdateSelectedCommand.mock.calls.length).toBe(1)
   })
 
   // TODO more tests ...


### PR DESCRIPTION
Thank you for contributing this pull request!

Please make the PR against the `master` branch, add a description of what's changing, and link any relevant issues or PRs.

## What's changing

Additional jest tests for OneField.jsx to increase code coverage.

## What else might be impacted? 

...

## Checklist

[ ] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.32.476.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
