### PR TITLE
updating the command to support crx 3

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -13,7 +13,7 @@
     "build:dev": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules --config webpack.config.js",
     "clean": "rm -r dist/",
     "version": "node extension/manifestUpdater.js && git add extension/manifest.json",
-    "package": "crx pack dist/ext -o dist/replayui.crx",
+    "package": "crx pack dist/ext --crx-version 3 -o dist/replayui.crx",
     "test": "BABEL_ENV=test jest --coverage",
     "test:watch": "BABEL_ENV=test jest --watch"
   },


### PR DESCRIPTION
Fixing https://github.com/intuit/ReplayWeb/issues/20

## What's changing

command is updated to support crx version 3


## What else might be impacted? 

...

## Checklist

[ ] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.37.569.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
