### PR TITLE
test: add async tests for suite extentions

### DIFF
--- a/packages/extension/test/actions/suites.test.js
+++ b/packages/extension/test/actions/suites.test.js
@@ -1,6 +1,16 @@
-import { addTestToSuite, removeTestFromSuite } from '../../src/actions/suites'
+import { addTestToSuite, removeTestFromSuite, createSuite, updateSuite, removeSuite } from '../../src/actions/suites'
+import { mockStore } from '../utils'
 
-jest.mock('../../src/actions/editor')
+jest.mock('../../src/models/suite_model', () => ({
+    insert: jest.fn().mockResolvedValue(),
+    listByProject: jest.fn().mockResolvedValue([{id: 1}, {id: 2}]),
+    remove: jest.fn().mockResolvedValue(),
+    update: jest.fn().mockResolvedValue()
+}))
+
+jest.mock('../../src/actions/editor', () => ({
+    setSuites: () => ({type: 'SET_SUITE_MOCK'})
+}))
 jest.mock('../../src/actions/action_types', () => (
     {
         types: {
@@ -22,5 +32,39 @@ describe('action suites utils', () => {
             test: 'mockTest',
             type: 'MOCK_REMOVE_SUITE_TEST'
         })
+    })
+})
+
+describe('action suites thunk utils', () => {
+    let store
+    beforeEach(() => {
+        store = mockStore({
+            editor: {
+                project: {
+                    id: 1
+                }
+            }
+        })
+    })
+
+    it('createSuite', () => {
+        return store.dispatch(createSuite({id: 1}))
+            .then(() => {
+                expect(store.getActions()).toEqual([{type: 'SET_SUITE_MOCK'}])
+            })
+    })
+
+    it('updateSuite', () => {
+        return store.dispatch(updateSuite({id: 1}))
+            .then(() => {
+                expect(store.getActions()).toEqual([{type: 'SET_SUITE_MOCK'}])
+            })
+    })
+
+    it('removeSuite', () => {
+        return store.dispatch(removeSuite({id: 1}))
+            .then(() => {
+                expect(store.getActions()).toEqual([{type: 'SET_SUITE_MOCK'}])
+            })
     })
 })


### PR DESCRIPTION
Thank you for contributing this pull request!

Please make the PR against the `master` branch, add a description of what's changing, and link any relevant issues or PRs.

## What's changing
just getting suite.js coverage to 100% by testing using the thunk pattern
...

## What else might be impacted? 

...

## Checklist

[x] Unit tests (updated and/or added)
[x] Documentation (function/class docs, comments, etc.)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.2-canary.39.583.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
