### PR TITLE
chore: added mode property flag to webpack config

### DIFF
--- a/packages/host/webpack.config.js
+++ b/packages/host/webpack.config.js
@@ -5,6 +5,7 @@ const PermissionsPlugin = require('webpack-permissions-plugin')
 
 module.exports = {
   target: 'node',
+  mode: 'production',
   entry: './src/index.js',
   resolve: {
     extensions: ['.js', '.jsx']

--- a/packages/utils/webpack.config.js
+++ b/packages/utils/webpack.config.js
@@ -5,6 +5,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const name = 'replay-utils'
 module.exports = {
   target: 'node',
+  mode: 'production',
   entry: path.join(__dirname, 'src', 'index.js'),
   resolve: {
     extensions: ['.js']


### PR DESCRIPTION
## What's changing
Removed webpack build warning from output due to the `mode` flag not being set
## What else might be impacted? 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.2-canary.41.624.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
