### PR TITLE
ShareBlockModal - increase test coverage

### DIFF
--- a/packages/extension/test/components/Modals/ShareBlockModal.test.js
+++ b/packages/extension/test/components/Modals/ShareBlockModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import ShareBlockModal from '../../../src/components/Modals/ShareBlockModal'
 
 jest.mock('../../../src/actions/index.js', () => ({}))
@@ -10,189 +10,270 @@ afterEach(() => {
 })
 
 describe('ShareBlockModal', () => {
-  it('disables block sharing on invalid blockShareConfig', () => {
-    const { getByText, queryByTestId, rerender } = render(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfig={{}}
-        blockShareConfigError={true}
-        blockShareConfigErrorMessage="This is an error"
-        closeModal={() => {}}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
+  describe('share block', () => {
+    it('disables block sharing on invalid blockShareConfig', () => {
+      const { getByText, queryByTestId, rerender } = render(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfig={{}}
+          blockShareConfigError={true}
+          blockShareConfigErrorMessage="This is an error"
+          closeModal={() => {}}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
 
-    // This rerender is required with different props as the ShareBlockModal component uses
-    // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
-    // using rerender
-    rerender(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfig={{}}
-        blockShareConfigError={true}
-        blockShareConfigErrorMessage="This is an error"
-        closeModal={() => {}}
-        editing={{
+      // This rerender is required with different props as the ShareBlockModal component uses
+      // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
+      // using rerender
+      rerender(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfig={{}}
+          blockShareConfigError={true}
+          blockShareConfigErrorMessage="This is an error"
+          closeModal={() => {}}
+          editing={{
+            commands: [],
+            filterCommands: [],
+            meta: {},
+            shareEditing: false,
+            isImported: false
+          }}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
+      getByText('Unable to share block')
+
+      // share block button is not present
+      const shareButton = queryByTestId('shareBlockModal_shareButton')
+      expect(shareButton).toBeNull()
+
+      const reshareButton = queryByTestId('shareBlockModal_reshareButton')
+      expect(reshareButton).toBeNull()
+
+      const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
+      expect(duplicateButton).toBeNull()
+    })
+
+    it('enables block sharing on valid blockShareConfig', () => {
+      const { queryByText, getByTestId, queryByTestId, rerender } = render(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfigError={false}
+          blockShareConfigErrorMessage=""
+          blockShareConfig={{}}
+          closeModal={() => {}}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
+
+      // This rerender is required with different props as the ShareBlockModal component uses
+      // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
+      // using rerender
+      rerender(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfigError={false}
+          blockShareConfigErrorMessage=""
+          blockShareConfig={{}}
+          closeModal={() => {}}
+          editing={{
+            commands: [],
+            filterCommands: [],
+            meta: {},
+            shareEditing: false,
+            isImported: false
+          }}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
+
+      expect(queryByText('Unable to share block')).toBeNull()
+
+      getByTestId('shareBlockModal_shareButton')
+
+      const reshareButton = queryByTestId('shareBlockModal_reshareButton')
+      expect(reshareButton).toBeNull()
+
+      const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
+      expect(duplicateButton).toBeNull()
+    })
+
+    it('call props.shareEditingBlock when button is clicked', () => {
+      const shareEditingBlockStub = jest.fn().mockResolvedValue({})
+
+      const initialProps = {
+        visible: true,
+        blockShareConfigError: false,
+        blockShareConfigErrorMessage: '',
+        blockShareConfig: {},
+        closeModal: () => {},
+        openDuplicate: () => {},
+        shareEditingBlock: shareEditingBlockStub
+      }
+      const { getByTestId, rerender } = render(
+        <ShareBlockModal {...initialProps} />
+      )
+
+      // rerender so that componentWillReceiveProps is called
+      const newProps = {
+        ...initialProps,
+        editing: {
           commands: [],
           filterCommands: [],
           meta: {},
           shareEditing: false,
           isImported: false
-        }}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
-    getByText('Unable to share block')
+        }
+      }
+      rerender(<ShareBlockModal {...newProps} />)
 
-    // share block button is not present
-    // const shareButton = container.querySelector("button");
-    const shareButton = queryByTestId('shareBlockModal_shareButton')
-    expect(shareButton).toBeNull()
-    const reshareButton = queryByTestId('shareBlockModal_reshareButton')
-    expect(reshareButton).toBeNull()
-    const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
-    expect(duplicateButton).toBeNull()
+      const button = getByTestId('shareBlockModal_shareButton')
+      fireEvent.click(button)
+      expect(shareEditingBlockStub).toHaveBeenCalled()
+    })
   })
 
-  it('enables block sharing on valid blockShareConfig', () => {
-    const { queryByText, getByTestId, queryByTestId, rerender } = render(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfigError={false}
-        blockShareConfigErrorMessage=""
-        blockShareConfig={{}}
-        closeModal={() => {}}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
+  describe('reshare block', () => {
+    it('disables block re-sharing on invalid blockShareConfig', () => {
+      const { getByText, queryByTestId, rerender } = render(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfig={{}}
+          blockShareConfigError={true}
+          blockShareConfigErrorMessage="This is an error"
+          closeModal={() => {}}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
 
-    // This rerender is required with different props as the ShareBlockModal component uses
-    // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
-    // using rerender
-    rerender(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfigError={false}
-        blockShareConfigErrorMessage=""
-        blockShareConfig={{}}
-        closeModal={() => {}}
-        editing={{
-          commands: [],
-          filterCommands: [],
-          meta: {},
-          shareEditing: false,
-          isImported: false
-        }}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
+      // This rerender is required with different props as the ShareBlockModal component uses
+      // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
+      // using rerender
+      rerender(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfig={{}}
+          blockShareConfigError={true}
+          blockShareConfigErrorMessage="This is an error"
+          closeModal={() => {}}
+          editing={{
+            commands: [],
+            filterCommands: [],
+            meta: {},
+            shareEditing: false,
+            isImported: false,
+            shareLink: 'a_link'
+          }}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
+      getByText('Unable to re-share block')
 
-    expect(queryByText('Unable to share block')).toBeNull()
+      // share block button is not present;
+      const shareButton = queryByTestId('shareBlockModal_shareButton')
+      expect(shareButton).toBeNull()
 
-    // share block button is not present
-    // const shareButton = container.querySelector("button");
-    getByTestId('shareBlockModal_shareButton')
-    const reshareButton = queryByTestId('shareBlockModal_reshareButton')
-    expect(reshareButton).toBeNull()
-    const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
-    expect(duplicateButton).toBeNull()
+      const reshareButton = queryByTestId('shareBlockModal_reshareButton')
+      expect(reshareButton).toBeNull()
+
+      const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
+      expect(duplicateButton).toBeNull()
+    })
+
+    it('enables block re-sharing on valid blockShareConfig', () => {
+      const { queryByText, getByTestId, queryByTestId, rerender } = render(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfigError={false}
+          blockShareConfigErrorMessage=""
+          blockShareConfig={{}}
+          closeModal={() => {}}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
+
+      // This rerender is required with different props as the ShareBlockModal component uses
+      // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
+      // using rerender
+      rerender(
+        <ShareBlockModal
+          visible={true}
+          blockShareConfigError={false}
+          blockShareConfigErrorMessage=""
+          blockShareConfig={{}}
+          closeModal={() => {}}
+          editing={{
+            commands: [],
+            filterCommands: [],
+            meta: {},
+            shareEditing: false,
+            isImported: false,
+            shareLink: 'a_link'
+          }}
+          openDuplicate={() => {}}
+          shareEditingBlock={() => {}}
+        />
+      )
+
+      expect(queryByText('Unable to share block')).toBeNull()
+        
+      getByTestId('shareBlockModal_reshareButton')
+
+       // share block button is not present
+      const shareButton = queryByTestId('shareBlockModal_shareButton')
+      expect(shareButton).toBeNull()
+
+      const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
+      expect(duplicateButton).toBeNull()
+    })
   })
+  describe('imported block', () => {
+    it('calls props.CloseModal and props.OpenDuplicate when reshare button button is clicked', () => {
+      const closeModalStub = jest.fn()
+      const openDuplicateStub = jest.fn()
 
-  it('disables block re-sharing on invalid blockShareConfig', () => {
-    const { getByText, queryByTestId, rerender } = render(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfig={{}}
-        blockShareConfigError={true}
-        blockShareConfigErrorMessage="This is an error"
-        closeModal={() => {}}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
+      const initialProps = {
+        visible: true,
+        blockShareConfigError: false,
+        blockShareConfigErrorMessage: '',
+        blockShareConfig: {},
+        closeModal: closeModalStub,
+        openDuplicate: openDuplicateStub,
+        shareEditingBlock: () => {}
+      }
 
-    // This rerender is required with different props as the ShareBlockModal component uses
-    // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
-    // using rerender
-    rerender(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfig={{}}
-        blockShareConfigError={true}
-        blockShareConfigErrorMessage="This is an error"
-        closeModal={() => {}}
-        editing={{
+      const { getByTestId, rerender } = render(
+        <ShareBlockModal {...initialProps} />
+      )
+
+      // rerender is required so thatcomponentWillReceiveProps is called
+
+      const newProps = {
+        ...initialProps,
+        editing: {
           commands: [],
           filterCommands: [],
-          meta: {},
+          meta: { src: { name: 'foo' } },
           shareEditing: false,
-          isImported: false,
+          isImported: true,
           shareLink: 'a_link'
-        }}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
-    getByText('Unable to re-share block')
+        }
+      }
+      rerender(<ShareBlockModal {...newProps} />)
 
-    // share block button is not present
-    // const shareButton = container.querySelector("button");
-    const shareButton = queryByTestId('shareBlockModal_shareButton')
-    expect(shareButton).toBeNull()
-    const reshareButton = queryByTestId('shareBlockModal_reshareButton')
-    expect(reshareButton).toBeNull()
-    const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
-    expect(duplicateButton).toBeNull()
-  })
-
-  it('enables block re-sharing on valid blockShareConfig', () => {
-    const { queryByText, getByTestId, queryByTestId, rerender } = render(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfigError={false}
-        blockShareConfigErrorMessage=""
-        blockShareConfig={{}}
-        closeModal={() => {}}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
-
-    // This rerender is required with different props as the ShareBlockModal component uses
-    // componentWillReceiveProps which only gets invoked when new props will be received. Forcing this new props
-    // using rerender
-    rerender(
-      <ShareBlockModal
-        visible={true}
-        blockShareConfigError={false}
-        blockShareConfigErrorMessage=""
-        blockShareConfig={{}}
-        closeModal={() => {}}
-        editing={{
-          commands: [],
-          filterCommands: [],
-          meta: {},
-          shareEditing: false,
-          isImported: false,
-          shareLink: 'a_link'
-        }}
-        openDuplicate={() => {}}
-        shareEditingBlock={() => {}}
-      />
-    )
-
-    expect(queryByText('Unable to share block')).toBeNull()
-
-    // share block button is not present
-    // const shareButton = container.querySelector("button");
-    getByTestId('shareBlockModal_reshareButton')
-    const shareButton = queryByTestId('shareBlockModal_shareButton')
-    expect(shareButton).toBeNull()
-    const duplicateButton = queryByTestId('shareBlockModal_duplicateButton')
-    expect(duplicateButton).toBeNull()
+      const button = getByTestId('shareBlockModal_duplicateButton')
+      fireEvent.click(button)
+      expect(closeModalStub).toHaveBeenCalled()
+      expect(openDuplicateStub).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## What's changing
- Added tests for ShareBlockModal component so that coverage is now 100% ( except for branches which is 75%). Was around 65% before.
- Small refactor to existing tests in same file to improve clarity

Part of: https://github.com/intuit/ReplayWeb/issues/5

...

## What else might be impacted? 
Nothing

...

## Checklist

[x] Unit tests (updated and/or added)
[ ] Documentation (function/class docs, comments, etc.) - N/A

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.5-canary.43.682.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
